### PR TITLE
Support min iOS v14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "bindings-swift",
     platforms: [
         .macOS(.v12),
-        .iOS(.v15),
+        .iOS(.v14),
     ],
     products: [
         .library(name: "BreezSDK", targets: ["breez_sdkFFI", "BreezSDK"]),


### PR DESCRIPTION
Hi, I am using breez-sdk on iOS as SPM dependency and it works like a charm.
It works good on iOS v14, too.
I don't see any min supported constrains on breez-sdk make procedure.
What do you think to setup iOS v14 as min supported platform?

thanks