### PR TITLE
Configure Cocoapods support

### DIFF
--- a/.github/workflows/publish-swift-package.yaml
+++ b/.github/workflows/publish-swift-package.yaml
@@ -1,4 +1,4 @@
-name: Publish Swift Package
+name: Publish Swift Bindings
 on:
   workflow_dispatch:
     inputs:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-tag-release:
-    name: Build, tag, and release the BreezSDK Swift Package
+    name: Build, tag, and release the Breez SDK Swift bindings
     runs-on: macOS-latest
     steps:
       - name: Install required dependencies
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: dist
-      - name: Build local Swift Package
+      - name: Build Swift bindings
         working-directory: build/libs/sdk-bindings
         env:
           SSH_PRIVATE_KEY: ${{secrets.REPO_SSH_KEY}}
@@ -37,22 +37,29 @@ jobs:
           ssh-add ~/.ssh/id_rsa
           make init
           make bindings-swift
-      - name: Compress Rust bindings XCFramework
+      - name: Compress XCFramework
         working-directory: build/libs/sdk-bindings/bindings-swift
         run: |
           zip -9 -r breez_sdkFFI.xcframework.zip breez_sdkFFI.xcframework
           echo "XCF_CHECKSUM=`swift package compute-checksum breez_sdkFFI.xcframework.zip`" >> $GITHUB_ENV
-      - name: Update the BreezSDK Swift Package
+      - name: Update Swift Package definition
         working-directory: build/libs/sdk-bindings/bindings-swift
         run: |
           sed 's#.binaryTarget(name: "breez_sdkFFI", path: "./breez_sdkFFI.xcframework"),#.binaryTarget(name: "breez_sdkFFI", url: "https://github.com/breez/breez-sdk-swift/releases/download/${{ inputs.version }}/breez_sdkFFI.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),#;/.testTarget(name: "BreezSDKTests", dependencies: \["BreezSDK"\]),/d' Package.swift > ../../../../dist/Package.swift
           cp -r Sources ../../../../dist
-      - name: Tag the BreezSDK Swift Package
+      - name: Update Cocoapods definitions
+        working-directory: dist
+        run: |
+          sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.version }}"#' breez_sdkFFI.podspec
+          sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.version }}"#' BreezSDK.podspec
+      - name: Tag the Swift bindings
         working-directory: dist
         run: |
           git add Package.swift
           git add Sources
-          git commit -m "Update BreezSDK to version ${{ inputs.version }}"
+          git add breez_sdkFFI.podspec
+          git add BreezSDK.podspec
+          git commit -m "Update Breez SDK Swift bindings to version ${{ inputs.version }}"
           git push
           git tag ${{ inputs.version }} -m "${{ inputs.version }}"
           git push --tags
@@ -64,3 +71,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ inputs.version }}
           prerelease: true
+      - name: Push update to Cocoapods trunk
+        working-directory: dist
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{secrets.COCOAPODS_TRUNK_TOKEN}}
+        run: |
+          pod trunk push breez_sdkFFI.podspec --allow-warnings
+          pod repo update
+          pod trunk push BreezSDK.podspec --allow-warnings

--- a/.github/workflows/publish-swift-package.yaml
+++ b/.github/workflows/publish-swift-package.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: dist
-          ref: cocoapods
       - name: Build Swift bindings
         working-directory: build/libs/sdk-bindings
         env:
@@ -38,43 +37,40 @@ jobs:
           ssh-add ~/.ssh/id_rsa
           make init
           make bindings-swift
-      # - name: Compress XCFramework
-      #   working-directory: build/libs/sdk-bindings/bindings-swift
-      #   run: |
-      #     zip -9 -r breez_sdkFFI.xcframework.zip breez_sdkFFI.xcframework
-      #     echo "XCF_CHECKSUM=`swift package compute-checksum breez_sdkFFI.xcframework.zip`" >> $GITHUB_ENV
-      # - name: Update Swift Package definition
-      #   working-directory: build/libs/sdk-bindings/bindings-swift
-      #   run: |
-      #     sed 's#.binaryTarget(name: "breez_sdkFFI", path: "./breez_sdkFFI.xcframework"),#.binaryTarget(name: "breez_sdkFFI", url: "https://github.com/breez/breez-sdk-swift/releases/download/${{ inputs.version }}/breez_sdkFFI.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),#;/.testTarget(name: "BreezSDKTests", dependencies: \["BreezSDK"\]),/d' Package.swift > ../../../../dist/Package.swift
-      #     cp -r Sources ../../../../dist
+      - name: Compress XCFramework
+        working-directory: build/libs/sdk-bindings/bindings-swift
+        run: |
+          zip -9 -r breez_sdkFFI.xcframework.zip breez_sdkFFI.xcframework
+          echo "XCF_CHECKSUM=`swift package compute-checksum breez_sdkFFI.xcframework.zip`" >> $GITHUB_ENV
+      - name: Update Swift Package definition
+        working-directory: build/libs/sdk-bindings/bindings-swift
+        run: |
+          sed 's#.binaryTarget(name: "breez_sdkFFI", path: "./breez_sdkFFI.xcframework"),#.binaryTarget(name: "breez_sdkFFI", url: "https://github.com/breez/breez-sdk-swift/releases/download/${{ inputs.version }}/breez_sdkFFI.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),#;/.testTarget(name: "BreezSDKTests", dependencies: \["BreezSDK"\]),/d' Package.swift > ../../../../dist/Package.swift
+          cp -r Sources ../../../../dist
       - name: Update Cocoapods definitions
         working-directory: dist
         run: |
           sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.version }}"#' breez_sdkFFI.podspec
           sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.version }}"#' BreezSDK.podspec
-          echo "DEBUG"
-          cat breez_sdkFFI.podspec
-          cat BreezSDK.podspec
-      # - name: Tag the Swift bindings
-      #   working-directory: dist
-      #   run: |
-      #     git add Package.swift
-      #     git add Sources
-      #     git add breez_sdkFFI.podspec
-      #     git add BreezSDK.podspec
-      #     git commit -m "Update Breez SDK Swift bindings to version ${{ inputs.version }}"
-      #     git push
-      #     git tag ${{ inputs.version }} -m "${{ inputs.version }}"
-      #     git push --tags
-      # - name: Release and attach XCFramework binary artifact
-      #   uses: ncipollo/release-action@v1
-      #   with:
-      #     artifacts: "build/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework.zip"
-      #     tag: ${{ inputs.version }}
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     name: ${{ inputs.version }}
-      #     prerelease: true
+      - name: Tag the Swift bindings
+        working-directory: dist
+        run: |
+          git add Package.swift
+          git add Sources
+          git add breez_sdkFFI.podspec
+          git add BreezSDK.podspec
+          git commit -m "Update Breez SDK Swift bindings to version ${{ inputs.version }}"
+          git push
+          git tag ${{ inputs.version }} -m "${{ inputs.version }}"
+          git push --tags
+      - name: Release and attach XCFramework binary artifact
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "build/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework.zip"
+          tag: ${{ inputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ inputs.version }}
+          prerelease: true
       - name: Push update to Cocoapods trunk
         working-directory: dist
         env:

--- a/.github/workflows/publish-swift-package.yaml
+++ b/.github/workflows/publish-swift-package.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: dist
+          ref: cocoapods
       - name: Build Swift bindings
         working-directory: build/libs/sdk-bindings
         env:
@@ -37,40 +38,43 @@ jobs:
           ssh-add ~/.ssh/id_rsa
           make init
           make bindings-swift
-      - name: Compress XCFramework
-        working-directory: build/libs/sdk-bindings/bindings-swift
-        run: |
-          zip -9 -r breez_sdkFFI.xcframework.zip breez_sdkFFI.xcframework
-          echo "XCF_CHECKSUM=`swift package compute-checksum breez_sdkFFI.xcframework.zip`" >> $GITHUB_ENV
-      - name: Update Swift Package definition
-        working-directory: build/libs/sdk-bindings/bindings-swift
-        run: |
-          sed 's#.binaryTarget(name: "breez_sdkFFI", path: "./breez_sdkFFI.xcframework"),#.binaryTarget(name: "breez_sdkFFI", url: "https://github.com/breez/breez-sdk-swift/releases/download/${{ inputs.version }}/breez_sdkFFI.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),#;/.testTarget(name: "BreezSDKTests", dependencies: \["BreezSDK"\]),/d' Package.swift > ../../../../dist/Package.swift
-          cp -r Sources ../../../../dist
+      # - name: Compress XCFramework
+      #   working-directory: build/libs/sdk-bindings/bindings-swift
+      #   run: |
+      #     zip -9 -r breez_sdkFFI.xcframework.zip breez_sdkFFI.xcframework
+      #     echo "XCF_CHECKSUM=`swift package compute-checksum breez_sdkFFI.xcframework.zip`" >> $GITHUB_ENV
+      # - name: Update Swift Package definition
+      #   working-directory: build/libs/sdk-bindings/bindings-swift
+      #   run: |
+      #     sed 's#.binaryTarget(name: "breez_sdkFFI", path: "./breez_sdkFFI.xcframework"),#.binaryTarget(name: "breez_sdkFFI", url: "https://github.com/breez/breez-sdk-swift/releases/download/${{ inputs.version }}/breez_sdkFFI.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),#;/.testTarget(name: "BreezSDKTests", dependencies: \["BreezSDK"\]),/d' Package.swift > ../../../../dist/Package.swift
+      #     cp -r Sources ../../../../dist
       - name: Update Cocoapods definitions
         working-directory: dist
         run: |
           sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.version }}"#' breez_sdkFFI.podspec
           sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.version }}"#' BreezSDK.podspec
-      - name: Tag the Swift bindings
-        working-directory: dist
-        run: |
-          git add Package.swift
-          git add Sources
-          git add breez_sdkFFI.podspec
-          git add BreezSDK.podspec
-          git commit -m "Update Breez SDK Swift bindings to version ${{ inputs.version }}"
-          git push
-          git tag ${{ inputs.version }} -m "${{ inputs.version }}"
-          git push --tags
-      - name: Release and attach XCFramework binary artifact
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "build/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework.zip"
-          tag: ${{ inputs.version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ inputs.version }}
-          prerelease: true
+          echo "DEBUG"
+          cat breez_sdkFFI.podspec
+          cat BreezSDK.podspec
+      # - name: Tag the Swift bindings
+      #   working-directory: dist
+      #   run: |
+      #     git add Package.swift
+      #     git add Sources
+      #     git add breez_sdkFFI.podspec
+      #     git add BreezSDK.podspec
+      #     git commit -m "Update Breez SDK Swift bindings to version ${{ inputs.version }}"
+      #     git push
+      #     git tag ${{ inputs.version }} -m "${{ inputs.version }}"
+      #     git push --tags
+      # - name: Release and attach XCFramework binary artifact
+      #   uses: ncipollo/release-action@v1
+      #   with:
+      #     artifacts: "build/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework.zip"
+      #     tag: ${{ inputs.version }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     name: ${{ inputs.version }}
+      #     prerelease: true
       - name: Push update to Cocoapods trunk
         working-directory: dist
         env:

--- a/.github/workflows/publish-swift-package.yaml
+++ b/.github/workflows/publish-swift-package.yaml
@@ -80,7 +80,5 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{secrets.COCOAPODS_TRUNK_TOKEN}}
         run: |
-          pod repo add cocoapods https://github.com/CocoaPods/Specs.git
           pod trunk push breez_sdkFFI.podspec --allow-warnings
-          pod repo update
-          pod trunk push BreezSDK.podspec --allow-warnings
+          pod trunk push BreezSDK.podspec --allow-warnings --synchronous

--- a/.github/workflows/publish-swift-package.yaml
+++ b/.github/workflows/publish-swift-package.yaml
@@ -80,6 +80,7 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{secrets.COCOAPODS_TRUNK_TOKEN}}
         run: |
+          pod repo add cocoapods https://github.com/CocoaPods/Specs.git
           pod trunk push breez_sdkFFI.podspec --allow-warnings
           pod repo update
           pod trunk push BreezSDK.podspec --allow-warnings

--- a/BreezSDK.podspec
+++ b/BreezSDK.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |spec|
+  spec.name                   = "BreezSDK"
+  spec.version                = "0.1.0"
+  spec.license                = { :type => "MIT" }
+  spec.summary                = "Swift bindings to the Breez SDK"
+  spec.homepage               = "https://breez.technology"
+  spec.authors                = { "Breez" => "contact@breez.technology" }
+  spec.documentation_url      = "https://sdk-doc.breez.technology"
+  spec.source                 = { :git => 'https://github.com/breez/breez-sdk-swift.git', :tag => spec.version }
+  spec.ios.deployment_target  = "15.0"
+  spec.source_files           = "Sources/BreezSDK/BreezSDK.swift"
+  spec.static_framework       = true
+
+  spec.dependency "breez_sdkFFI", "= #{spec.version}"
+end

--- a/breez_sdkFFI.podspec
+++ b/breez_sdkFFI.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |spec|
+  spec.name                   = "breez_sdkFFI"
+  spec.version                = "0.1.0"
+  spec.license                = { :type => "MIT" }
+  spec.summary                = "Low-level bindings to the Breez SDK Rust API"
+  spec.homepage               = "https://breez.technology"
+  spec.authors                = { "Breez" => "contact@breez.technology" }
+  spec.documentation_url      = "https://sdk-doc.breez.technology"
+  spec.source                 = { :http => "https://github.com/breez/breez-sdk-swift/releases/download/#{spec.version}/breez_sdkFFI.xcframework.zip" }
+  spec.ios.deployment_target  = "15.0"
+  spec.vendored_frameworks    = "breez_sdkFFI.xcframework"
+end


### PR DESCRIPTION
Tested the release automation by [releasing an old version (0.0.3)](https://github.com/breez/breez-sdk-swift/actions/runs/5205399400/jobs/9390801307) as Cocoapod using the CI workflow.

---

## Approach

Apparently, there is an issue with Cocoapods where you cannot have a podspec that declares both source files and a vendored framework where the sources need to be linked against the vendored framework. [1]

Therefore the solution is to publish two pods:

1. The pure XCFramework as `breez_sdkFFI`. This is not supposed to be consumed directly (although no harm is done if someone would do so) since it only provides the low-level Rust interface.
2. The UniFFI-generated Swift bindings as `BreezSDK` which depends on `breez_sdkFFI`.

Devs can then simply have a Podfile like so:

``` ruby
target 'ExampleApp' do
  use_frameworks!

  pod 'BreezSDK'
end
```

and will be able to use the Breez SDK in their apps:

``` swift
import BreezSDK

let seed = try! mnemonicToSeed(phrase: "...")
```

Which is pretty straight forward. 🙌 

## Releasing

Releases will be made automatically whenever we run the release workflow. CI will then update the Swift Package as well as the Pod.

[1]: https://stackoverflow.com/a/59779259/5233456