### PR TITLE
Update docs with cocoapods setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# 💡Contribution Guide
+
+This repository is used to publish a Swift package as well as a CocoaPod providing Swift bindings to the Breez SDK's [underlying Rust implementation](https://github.com/breez/breez-sdk). These Swift bindings are generated using [UniFFi](https://github.com/mozilla/uniffi-rs).
+
+## Changing the Breez SDK
+
+Any changes to the Breez SDK and its Swift bindings, must be made via the main [breez/breez-sdk](https://github.com/breez/breez-sdk) repository.
+
+## Swift Package Configuration
+
+The Swift package configuration maintained in the main [breez/breez-sdk](https://github.com/breez/breez-sdk/tree/main/libs/sdk-bindings/bindings-swift) repository and automatically copied to this repository by the release CI workflow. Therefore, any changes to the Swift Package configuration must be made in the main repository.
+
+## CocoaPods Configuration 
+
+The CocoaPod configuration is maintained in this repository and changes to it can be made in this repository directly.
+
+The CocoaPod configuration consists of two parts:
+
+- `breez_sdkFFI.podspec`: A CocoaPod publishing _just_ the Breez SDK's low-level Rust interface. This is not meant to be consumed directly.
+- `BreezSDK.podspec`: The main CocoaPod which depends on `breez_sdkFFI` and publishes high-level Swift bindings to the underlying Rust interface.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# BreezSDK – Swift Package
+# BreezSDK — Swift Bindings
 
-The [Breez SDK](https://github.com/breez/breez-sdk) enables mobile developers to integrate lightning and bitcoin payments into their apps with a very shallow learning curve. More information can be found [here](https://github.com/breez/breez-sdk).
+The [Breez SDK](https://github.com/breez/breez-sdk) enables mobile developers to integrate Lightning and bitcoin payments into their apps with a very shallow learning curve. More information can be found here: [breez/breez-sdk](https://github.com/breez/breez-sdk)
+
+This repository maintains the Breez SDK's official [Swift](https://www.swift.org/) bindings.
 
 ## 👨‍🔧 Installation
 
-This package is intended to be used with the [Swift Package Manager](https://www.swift.org/package-manager/).
+We support integration via the [Swift Package Manager](https://www.swift.org/package-manager/) and via [CocoaPods](https://cocoapods.org/).
 
-### Xcode
+### Swift Package Manager
+
+#### Installation via Xcode
 
 Via `File > Add Packages...`, add
 
@@ -16,12 +20,24 @@ https://github.com/breez/breez-sdk-swift.git
 
 as a package dependency in Xcode.
 
-### Swift Package
+#### Installation via Swift Package Manifest
 
-Add the following to the dependencies array in your `Package.swift`:
+Add the following to the dependencies array of your `Package.swift`:
 
 ``` swift
 .package(url: "https://github.com/breez/breez-sdk-swift.git", from: "0.0.4"),
+```
+
+### CocoaPods
+
+Add the Breez SDK to your `Podfile` like so:
+
+``` ruby
+target '<YourApp' do
+  use_frameworks!
+
+  pod 'BreezSDK'
+end
 ```
 
 ## 📄 Usage
@@ -29,13 +45,13 @@ Add the following to the dependencies array in your `Package.swift`:
 ``` swift
 import BreezSDK
 
-// Todo
+// See: https://sdk-doc.breez.technology
 ```
 
-## 💡 Information for Maintainers and Contributors
+## 🚀 Releasing
 
-This repository is used to publish a Swift package providing Swift bindings to the Breez SDK's [underlying Rust implementation](https://github.com/breez/breez-sdk). The Swift bindings are generated using [UniFFi](https://github.com/mozilla/uniffi-rs).
+To release a new version of the Swift bindings:
 
-Any changes to the Breez SDK, the Swift bindings, and the configuration of this Swift package must be made via the [breez-sdk](https://github.com/breez/breez-sdk) repo.
-
-To release a new version of this package, go to the Actions tab of this GitHub repository. Then select the *Publish Swift Package* workflow and run it on the `main` branch. It will ask for a version as input. This allows you to specify the version (e.g., *0.0.1*) of the [breez-sdk](https://github.com/breez/breez-sdk) repository that should be released as a Swift package.
+1. Go to the Actions tab of this GitHub repository. 
+1. Select the *Publish Swift Package* workflow and run it on the `main` branch.
+1. It will ask for a version as input. The version you input here needs to correspond to an already existing version (e.g., *0.0.1*) of the main [breez-sdk](https://github.com/breez/breez-sdk) repository.


### PR DESCRIPTION
- Updates the docs to include information on how to install via CocoaPods after merging #7.
- Also updates the information for contributers and moves it to a separate file to keep the readme short and tidy.