### PR TITLE
Drop cocoapods deployment target to ios 11

### DIFF
--- a/BreezSDK.podspec
+++ b/BreezSDK.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
   spec.authors                = { "Breez" => "contact@breez.technology" }
   spec.documentation_url      = "https://sdk-doc.breez.technology"
   spec.source                 = { :git => 'https://github.com/breez/breez-sdk-swift.git', :tag => spec.version }
-  spec.ios.deployment_target  = "15.0"
+  spec.ios.deployment_target  = "11.0"
   spec.source_files           = "Sources/BreezSDK/BreezSDK.swift"
   spec.static_framework       = true
 

--- a/breez_sdkFFI.podspec
+++ b/breez_sdkFFI.podspec
@@ -7,6 +7,6 @@ Pod::Spec.new do |spec|
   spec.authors                = { "Breez" => "contact@breez.technology" }
   spec.documentation_url      = "https://sdk-doc.breez.technology"
   spec.source                 = { :http => "https://github.com/breez/breez-sdk-swift/releases/download/#{spec.version}/breez_sdkFFI.xcframework.zip" }
-  spec.ios.deployment_target  = "15.0"
+  spec.ios.deployment_target  = "11.0"
   spec.vendored_frameworks    = "breez_sdkFFI.xcframework"
 end


### PR DESCRIPTION
- I don’t think the generated BreezSDK.swit makes use of any iOS specific APIs so that should be fine on whatever iOS version.
- Swift itself didn’t have a breaking change all the way back to iOS 11 when Swift 5 was introduced.

Therefore, I think, we should be fine with requiring iOS 11+. Unfortunately, my Xcode only allows me to install simulator runtimes for 14.0 but not lower than that so I cannot really test this hypothesis.

_Companion PR for the Swift package: https://github.com/breez/breez-sdk/pull/262_